### PR TITLE
fix conditional if and add if elseif else if full structure

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -449,17 +449,25 @@
 			"prefix": "<\\$buttonp",
 			"body": "<\\$button popup=${1:\"$:/state/${2:state}\"}>\n  ${3:Label}\n</\\$button>$0"
 		},
-		"Shortcut - If Endif": {
+		"Shortcut - If EndIf": {
 			"prefix": ["<% if endif"],
 			"body": "<% if ${1:[${2:operator}[]]} %>\n\t${3:Content}\n<% endif %>$0"
 		},
 		"Shortcut - If ElseIf Else EndIf": {
 			"prefix": ["<% if else endif"],
-			"body": "<% if ${1:[${2:operator}[]]} %>\n\t${3:Content}\n<% elseif ${4:[${5:operator}[]]} %>\n\t${6:Content}\n<% else %>\n\t${7:Content}\n<% endif %>$0"
+			"body": [
+				"<% if ${1:[${2:operator}[]]} %>",
+					"\t${3:Content}",
+				"<% elseif ${4:[${5:operator}[]]} %>",
+					"\t${6:Content}",
+				"<% else %>",
+					"\t${7:Content}",
+				"<% endif %>$0"
+			]
 		},
 		"Shortcut - Else If": {
 			"prefix": ["<% elseif if"],
-			"body": "<% elseif ${1:[${2:operator}[]] %>\n\t${3:Content}\n$0"
+			"body": "<% elseif ${1:[${2:operator}[]]} %>\n\t${3:Content}\n$0"
 		},
 		"Shortcut - Else": {
 			"prefix": ["<% else no if"],

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -449,16 +449,20 @@
 			"prefix": "<\\$buttonp",
 			"body": "<\\$button popup=${1:\"$:/state/${2:state}\"}>\n  ${3:Label}\n</\\$button>$0"
 		},
-		"Shortcut Conditional If": {
-			"prefix": "<% if",
-			"body": "<% if ${1:[${2:title}[]] %>\n${3:Content}\n<% endif %>$0"
+		"Shortcut - If Endif": {
+			"prefix": ["<% if endif"],
+			"body": "<% if ${1:[${2:operator}[]]} %>\n${3:Content}\n<% endif %>$0"
 		},
-		"Shortcut Conditional IfElse": {
-			"prefix": "<% ifelse",
-			"body": "<% ifelse ${1:[${2:title}[]] %>\n${3:Content}\n$0"
+		"Shortcut - If ElseIf Else EndIf": {
+			"prefix": ["<% if else endif"],
+			"body": "<% if ${1:[${2:operator}[]]} %>\n\t${3:Content}\n<% elseif ${4:[${5:operator}[]]} %>\n\t${6:Content}\n<% else %>\n\t${7:Content}\n<% endif %>$0"
 		},
-		"Shortcut Conditional Else": {
-			"prefix": "<% else",
+		"Shortcut - Else If": {
+			"prefix": ["<% elseif if"],
+			"body": "<% elseif ${1:[${2:operator}[]] %>\n${3:Content}\n$0"
+		},
+		"Shortcut - Else": {
+			"prefix": ["<% else no if"],
 			"body": "<% else %>\n${1:Content}\n$0"
 		}
 	},

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -451,7 +451,7 @@
 		},
 		"Shortcut - If Endif": {
 			"prefix": ["<% if endif"],
-			"body": "<% if ${1:[${2:operator}[]]} %>\n${3:Content}\n<% endif %>$0"
+			"body": "<% if ${1:[${2:operator}[]]} %>\n\t${3:Content}\n<% endif %>$0"
 		},
 		"Shortcut - If ElseIf Else EndIf": {
 			"prefix": ["<% if else endif"],
@@ -459,11 +459,11 @@
 		},
 		"Shortcut - Else If": {
 			"prefix": ["<% elseif if"],
-			"body": "<% elseif ${1:[${2:operator}[]] %>\n${3:Content}\n$0"
+			"body": "<% elseif ${1:[${2:operator}[]] %>\n\t${3:Content}\n$0"
 		},
 		"Shortcut - Else": {
 			"prefix": ["<% else no if"],
-			"body": "<% else %>\n${1:Content}\n$0"
+			"body": "<% else %>\n\t${1:Content}\n$0"
 		}
 	},
 	".meta.widget.tw-button.tiddlywiki5 > .meta.body.tiddlywiki5,\n.meta.widget.tw-keyboard.tiddlywiki5 > .meta.body.tiddlywiki5": {


### PR DESCRIPTION
This PR fixes a problem with the wrong syntax for `<% elseif %>` -> Currently it's `<% ifelse %>` which is wrong.

If the user types `if` this popup comes up

![image](https://github.com/joshuafontany/VSCode-TW5-Syntax/assets/374655/f0c79d89-ddf6-4769-8bd8-476dc5ad3015)

and `else` shows this

![image](https://github.com/joshuafontany/VSCode-TW5-Syntax/assets/374655/9fcf621f-a860-4039-8d92-e64da8626ff6)

I think that's extremely convenient


