### PR TITLE
add fnprocdef to rulestyle definition snippet

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -47,7 +47,7 @@
 		},
 		"Rules Stylesheet Pragma": {
 			"prefix": "\\rulesstyle",
-			"body": "\\\\rules only filteredtranscludeinline transcludeinline macrodef macrocallinline$0\n"
+			"body": "\\\\rules only filteredtranscludeinline transcludeinline macrodef fnprocdef macrocallinline$0\n"
 		},
 		"Rules Plain Text Pragma": {
 			"prefix": "\\rulesoff",


### PR DESCRIPTION
This PR adds a missing `fnprocdef` to the **rulestyle** snippet