### PR TITLE
fix the whitespace pragma

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -55,7 +55,7 @@
 		},
 		"Whitespace Pragma": {
 			"prefix": "\\whitespace",
-			"body": "\\\\rules ${1|trim,notrim|}\n"
+			"body": "\\\\whitespace ${1|trim,notrim|}\n"
 		},
 		"Code": {
 			"prefix": "```code",


### PR DESCRIPTION
This PR fixes the `\whitespace` pragma. It uses `\rules` atm. So it seems to be a copy/paste oversight