### PR TITLE
fix trt and tit snippet shortcuts

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -107,7 +107,7 @@
 		},
 		"Transclusion With Template": {
 			"prefix": "{{trt",
-			"body": "{{${1:tiddler}||${2:template}}$0"
+			"body": "{{${1:tiddler}||${2:template}}}$0"
 		},
 		"Transclusion Of Field With Template": {
 			"prefix": "{{tft",
@@ -115,7 +115,7 @@
 		},
 		"Transclusion Of Data Index With Template": {
 			"prefix": "{{tit",
-			"body": "{{${1:}##${2:index}||${3:template}}$0"
+			"body": "{{${1:}##${2:index}||${3:template}}}$0"
 		},
 		"Table": {
 			"prefix": "|table",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -100,7 +100,7 @@
 		"Transclusion Of Field": {
 			"prefix": "{{tf",
 			"body": "{{${1:}!!${2:title}}}$0"
-		},
+		},4
 		"Transclusion Of Data Index": {
 			"prefix": "{{ti",
 			"body": "{{${1:}##${2:index}}}$0"
@@ -111,7 +111,7 @@
 		},
 		"Transclusion Of Field With Template": {
 			"prefix": "{{tft",
-			"body": "{{${1:}!!${2:title}||${3:template}}$0"
+			"body": "{{${1:}!!${2:title}||${3:template}}}$0"
 		},
 		"Transclusion Of Data Index With Template": {
 			"prefix": "{{tit",

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -100,7 +100,7 @@
 		"Transclusion Of Field": {
 			"prefix": "{{tf",
 			"body": "{{${1:}!!${2:title}}}$0"
-		},4
+		},
 		"Transclusion Of Data Index": {
 			"prefix": "{{ti",
 			"body": "{{${1:}##${2:index}}}$0"


### PR DESCRIPTION
fix trt and tit snippet shortcuts

trt atm produces `{{tiddler||template}`  which is missing a closing brace. The same is true for the "tit" snippet