### PR TITLE
replace tabs with spaces in tablerc

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -131,7 +131,7 @@
 		},
 		"Table With Row And Column Headers": {
 			"prefix": "|tablerc",
-			"body": "|\t\t\t\t\t\t\t|${1:Header One}\t|h\n|!${2:Header One}\t|${3:Data One}\t\t|\n|!${4:Header Two}\t|${5:Data Two}\t\t|"
+			"body": "|            | ${1:Header One} |h\n|!${2:Header One} |${3:Data One}    |\n|!${4:Header Two} |${5:Data Two}    |"
 		},
 		"Quote": {
 			"prefix": ">q",


### PR DESCRIPTION
This PR replaces tabs with spaces in tablerc, since tabs can be set to different width.

So every editor may create a different result and most of them do not align. 
Spaces will always align.