### PR TITLE
make sup, sub and inline code snippets more reachable with non english keyboard layouts

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -170,11 +170,11 @@
 			"body": "__$1__$0"
 		},
 		"Superscript": {
-			"prefix": "^^sup",
+			"prefix": "^^ sup",
 			"body": "^^$1^^$0"
 		},
 		"Subscript": {
-			"prefix": ",,sub",
+			"prefix": ",, sub",
 			"body": ",,$1,,$0"
 		},
 		"Strikethrough": {
@@ -182,11 +182,11 @@
 			"body": "~~$1~~$0"
 		},
 		"Code Inline Single Backticks": {
-			"prefix": "`code",
+			"prefix": "`code ic",
 			"body": "`$1`$0"
 		},
 		"Code Inline Double Backticks": {
-			"prefix": "``code",
+			"prefix": "``code ic",
 			"body": "``$1``$0"
 		},
 		"Preformatted Text": {


### PR DESCRIPTION
This PR makes `sup`, `sub` and `inline code` snippets more reachable with non English keyboard layouts.

now `sup`, `sub` and `ic` will show the right snippet shortcuts